### PR TITLE
Update rule-condition-service-decoration.js

### DIFF
--- a/src/Resources/app/administration/src/decorator/rule-condition-service-decoration.js
+++ b/src/Resources/app/administration/src/decorator/rule-condition-service-decoration.js
@@ -1,4 +1,4 @@
-import { Application } from 'src/core/shopware';
+const Application = Shopware.Application;
 import '../core/component/swag-lunar-eclipse';
 
 Application.addServiceProviderDecorator('ruleConditionDataProviderService', (ruleConditionService) => {


### PR DESCRIPTION
You can't use imports directly from the Shopware Core via "src/core/shopware". Use the global Shopware object directly instead.